### PR TITLE
Fix compile errors after Sentence entity update

### DIFF
--- a/lib/presentation/providers/review_provider.dart
+++ b/lib/presentation/providers/review_provider.dart
@@ -61,7 +61,7 @@ class ReviewProvider extends ChangeNotifier {
     notifyListeners();
 
     // 3) Exclude the IDs we’ve already shown (in that same language), then fetch the rest:
-    final excludeIds = _sentences.map((s) => s.id).toList();
+    final excludeIds = _sentences.map((s) => s.id(langCode)).toList();
     final rest = await _learning.getRemainingSentencesForWord(
       currentWord!.text,
       excludeIds,

--- a/lib/presentation/screens/review_screen.dart
+++ b/lib/presentation/screens/review_screen.dart
@@ -67,7 +67,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
     if (s != null) {
       final langCode =
           context.read<SettingsProvider>().learningLanguageCodes.first;
-      await _loadAudioForSentence(s.id);
+      await _loadAudioForSentence(s.id(langCode));
     }
   }
 
@@ -199,7 +199,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id);
+                        _loadAudioForSentence(nxt.id(langCode));
                       }
                     },
                     onNextSentence: () {
@@ -211,7 +211,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id);
+                        _loadAudioForSentence(nxt.id(langCode));
                       }
                     },
                   ),
@@ -240,7 +240,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                         .read<SettingsProvider>()
                                         .learningLanguageCodes
                                         .first;
-                                _loadAudioForSentence(nxt.id);
+                                _loadAudioForSentence(nxt.id(langCode));
                               }
                             },
                             child: Text(label),

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -107,11 +107,11 @@ class _StudyScreenState extends State<StudyScreen> {
     });
 
     if (initial.isNotEmpty) {
-      await _loadAudioForSentence(initial[0].id);
+      await _loadAudioForSentence(initial[0].id(langCode));
     }
 
     // 2) fetch “the rest”
-    final excludeIds = initial.map((s) => s.id).toList();
+    final excludeIds = initial.map((s) => s.id(langCode)).toList();
     final rest = await _learningService.getRemainingSentencesForWord(
       batch.first.text,
       excludeIds,
@@ -220,7 +220,7 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id);
+    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
   }
 
   void _prevSentence() {
@@ -232,7 +232,7 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id);
+    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
   }
 
   @override

--- a/lib/presentation/widgets/interactive_word_sentence_card.dart
+++ b/lib/presentation/widgets/interactive_word_sentence_card.dart
@@ -149,7 +149,7 @@ class _InteractiveWordSentenceCardState
     final dir = await getTemporaryDirectory();
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    final sid = widget.sentences[widget.sentenceIndex].id;
+    final sid = widget.sentences[widget.sentenceIndex].id(langCode);
     final path = '${dir.path}/user_$sid.wav';
 
     await _recorder.start(
@@ -216,7 +216,8 @@ class _InteractiveWordSentenceCardState
     _whisperStart = DateTime.now();
     final result = await _checker.compare(
       userAudioPath: userPath,
-      expectedText: widget.sentences[widget.sentenceIndex].text,
+      expectedText:
+          widget.sentences[widget.sentenceIndex].text(langCode),
       lang: langCode,
     );
     _whisperEnd = DateTime.now();
@@ -366,7 +367,7 @@ class _InteractiveWordSentenceCardState
                                   : (_whisperTranscription.isNotEmpty
                                       ? _buildColorizedSentence(
                                         theme,
-                                        current!.textFor(learnCode),
+                                        current!.text(learnCode),
                                       )
                                       : Row(
                                         children: [
@@ -378,7 +379,7 @@ class _InteractiveWordSentenceCardState
                                           const SizedBox(width: 8),
                                           Expanded(
                                             child: SelectableText(
-                                              current!.textFor(learnCode),
+                                              current!.text(learnCode),
                                               style: theme.titleMedium!
                                                   .copyWith(
                                                     fontWeight: FontWeight.bold,
@@ -398,7 +399,7 @@ class _InteractiveWordSentenceCardState
                               children: [
                                 Expanded(
                                   child: SelectableText(
-                                    current!.textFor(translateCode),
+                                    current!.text(translateCode),
                                     style: theme.bodyMedium,
                                     textAlign: TextAlign.center,
                                   ),

--- a/lib/services/learning_service.dart
+++ b/lib/services/learning_service.dart
@@ -94,7 +94,7 @@ class LearningService {
   ) async {
     final all = await sentenceRepo.fetchForWord(wordText, languageCode);
     return all
-        .where((s) => !excludeIds.contains(s.idFor(languageCode)))
+        .where((s) => !excludeIds.contains(s.id(languageCode)))
         .toList();
   }
 


### PR DESCRIPTION
## Summary
- update callers to use `Sentence.id(code)` and `Sentence.text(code)`
- reflect updated API in review & study screens and provider
- filter sentences correctly by language in `LearningService`

## Testing
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68402cbd9bf08321bda5e302ae3e82ab