### PR TITLE
Fix compile errors after Sentence entity update

### DIFF
--- a/lib/presentation/providers/review_provider.dart
+++ b/lib/presentation/providers/review_provider.dart
@@ -61,7 +61,7 @@ class ReviewProvider extends ChangeNotifier {
     notifyListeners();
 
     // 3) Exclude the IDs we’ve already shown (in that same language), then fetch the rest:
-    final excludeIds = _sentences.map((s) => s.id).toList();
+    final excludeIds = _sentences.map((s) => s.id(langCode)).toList();
     final rest = await _learning.getRemainingSentencesForWord(
       currentWord!.text,
       excludeIds,

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -144,6 +144,24 @@ class SettingsProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Change the active learning language. The provided [code] must already
+  /// exist in the list; it will be moved to the front so that callers using
+  /// `learningLanguageCodes.first` see the new language.
+  Future<void> switchLearningLanguage(String code) async {
+    if (!_learningLanguageCodes.contains(code) ||
+        _learningLanguageCodes.first == code) {
+      return;
+    }
+
+    _learningLanguageCodes
+      ..remove(code)
+      ..insert(0, code);
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kLearningLanguagesKey, _learningLanguageCodes);
+    notifyListeners();
+  }
+
   /// Public API to force a full reload (e.g. on resume).
   Future<void> reload() async {
     await _loadAll();

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -43,7 +43,16 @@ class HomeScreen extends StatelessWidget {
                     style: const TextStyle(color: Colors.white),
                   ),
                   onSelected: (value) {
-                    // тут можно потом добавить логику переключения между изучаемыми
+                    if (value == 'add_more') {
+                      // No "add language" screen yet
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Feature coming soon')),
+                      );
+                      return;
+                    }
+                    context
+                        .read<SettingsProvider>()
+                        .switchLearningLanguage(value);
                   },
                   itemBuilder: (_) {
                     final langs = settingsProvider.learningLanguageCodes;

--- a/lib/presentation/screens/review_screen.dart
+++ b/lib/presentation/screens/review_screen.dart
@@ -67,7 +67,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
     if (s != null) {
       final langCode =
           context.read<SettingsProvider>().learningLanguageCodes.first;
-      await _loadAudioForSentence(s.id);
+      await _loadAudioForSentence(s.id(langCode));
     }
   }
 
@@ -199,7 +199,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id);
+                        _loadAudioForSentence(nxt.id(langCode));
                       }
                     },
                     onNextSentence: () {
@@ -211,7 +211,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id);
+                        _loadAudioForSentence(nxt.id(langCode));
                       }
                     },
                   ),
@@ -240,7 +240,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                         .read<SettingsProvider>()
                                         .learningLanguageCodes
                                         .first;
-                                _loadAudioForSentence(nxt.id);
+                                _loadAudioForSentence(nxt.id(langCode));
                               }
                             },
                             child: Text(label),

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -107,11 +107,11 @@ class _StudyScreenState extends State<StudyScreen> {
     });
 
     if (initial.isNotEmpty) {
-      await _loadAudioForSentence(initial[0].id);
+      await _loadAudioForSentence(initial[0].id(langCode));
     }
 
     // 2) fetch “the rest”
-    final excludeIds = initial.map((s) => s.id).toList();
+    final excludeIds = initial.map((s) => s.id(langCode)).toList();
     final rest = await _learningService.getRemainingSentencesForWord(
       batch.first.text,
       excludeIds,
@@ -220,7 +220,7 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id);
+    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
   }
 
   void _prevSentence() {
@@ -232,7 +232,7 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id);
+    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
   }
 
   @override

--- a/lib/services/learning_service.dart
+++ b/lib/services/learning_service.dart
@@ -94,7 +94,7 @@ class LearningService {
   ) async {
     final all = await sentenceRepo.fetchForWord(wordText, languageCode);
     return all
-        .where((s) => !excludeIds.contains(s.idFor(languageCode)))
+        .where((s) => !excludeIds.contains(s.id(languageCode)))
         .toList();
   }
 


### PR DESCRIPTION
## Summary
- update callers to use `Sentence.id(code)` and `Sentence.text(code)`
- reflect updated API in review & study screens and provider
- filter sentences correctly by language in `LearningService`
- implement language switching from HomeScreen menu

## Testing
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68402cbd9bf08321bda5e302ae3e82ab