### PR TITLE
Add ability to add new learning languages

### DIFF
--- a/lib/core/app_language.dart
+++ b/lib/core/app_language.dart
@@ -50,6 +50,40 @@ extension AppLanguageExtension on AppLanguage {
     }
   }
 
+  String get flag {
+    String countryCode;
+    switch (this) {
+      case AppLanguage.english:
+        countryCode = 'GB';
+        break;
+      case AppLanguage.spanish:
+        countryCode = 'ES';
+        break;
+      case AppLanguage.russian:
+        countryCode = 'RU';
+        break;
+      case AppLanguage.french:
+        countryCode = 'FR';
+        break;
+      case AppLanguage.german:
+        countryCode = 'DE';
+        break;
+      case AppLanguage.italian:
+        countryCode = 'IT';
+        break;
+      case AppLanguage.portuguese:
+        countryCode = 'PT';
+        break;
+    }
+    // Convert ASCII country code to regional indicator symbols.
+    final base = 0x1F1E6 - 'A'.codeUnitAt(0);
+    final chars = countryCode.codeUnits
+        .map((c) => base + c)
+        .map((code) => String.fromCharCode(code))
+        .join();
+    return chars;
+  }
+
   static AppLanguage? fromCode(String code) {
     switch (code) {
       case 'en':

--- a/lib/presentation/providers/review_provider.dart
+++ b/lib/presentation/providers/review_provider.dart
@@ -61,7 +61,7 @@ class ReviewProvider extends ChangeNotifier {
     notifyListeners();
 
     // 3) Exclude the IDs we’ve already shown (in that same language), then fetch the rest:
-    final excludeIds = _sentences.map((s) => s.id).toList();
+    final excludeIds = _sentences.map((s) => s.id(langCode)).toList();
     final rest = await _learning.getRemainingSentencesForWord(
       currentWord!.text,
       excludeIds,

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -144,6 +144,36 @@ class SettingsProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Add a new learning language if it isn't already selected and isn't the
+  /// native language.
+  Future<void> addLearningLanguage(String code) async {
+    if (_learningLanguageCodes.contains(code) || _nativeLanguageCode == code) {
+      return;
+    }
+    _learningLanguageCodes.add(code);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kLearningLanguagesKey, _learningLanguageCodes);
+    notifyListeners();
+  }
+
+  /// Change the active learning language. The provided [code] must already
+  /// exist in the list; it will be moved to the front so that callers using
+  /// `learningLanguageCodes.first` see the new language.
+  Future<void> switchLearningLanguage(String code) async {
+    if (!_learningLanguageCodes.contains(code) ||
+        _learningLanguageCodes.first == code) {
+      return;
+    }
+
+    _learningLanguageCodes
+      ..remove(code)
+      ..insert(0, code);
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kLearningLanguagesKey, _learningLanguageCodes);
+    notifyListeners();
+  }
+
   /// Public API to force a full reload (e.g. on resume).
   Future<void> reload() async {
     await _loadAll();

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -9,6 +9,39 @@ import '../providers/settings_provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:learn_languages/core/app_language.dart';
 
+void _showAddLanguageDialog(BuildContext context) {
+  final settings = context.read<SettingsProvider>();
+  final nativeCode = settings.nativeLanguageCode;
+  final current = settings.learningLanguageCodes;
+  final available = AppLanguage.values
+      .where((lang) =>
+          lang.code != nativeCode && !current.contains(lang.code))
+      .toList();
+
+  if (available.isEmpty) return;
+
+  showModalBottomSheet(
+    context: context,
+    builder: (ctx) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final lang in available)
+              ListTile(
+                title: Text('${lang.flag} ${lang.displayName}'),
+                onTap: () {
+                  settings.addLearningLanguage(lang.code);
+                  Navigator.of(ctx).pop();
+                },
+              ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);
 
@@ -24,46 +57,16 @@ class HomeScreen extends StatelessWidget {
     final streak = settingsProvider.streakCount;
     final loc = AppLocalizations.of(context)!;
     final learningCodes = settingsProvider.learningLanguageCodes;
-    final leadCode =
-        learningCodes.isNotEmpty
-            ? AppLanguageExtension.fromCode(learningCodes.first)?.displayName ??
-                ''
-            : '';
+    final leadCode = learningCodes.isNotEmpty
+        ? AppLanguageExtension.fromCode(learningCodes.first)?.displayName ?? ''
+        : '';
 
     return Scaffold(
       backgroundColor: Colors.transparent,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         elevation: 0,
-        leading:
-            leadCode.isNotEmpty
-                ? PopupMenuButton<String>(
-                  icon: Text(
-                    leadCode,
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                  onSelected: (value) {
-                    // тут можно потом добавить логику переключения между изучаемыми
-                  },
-                  itemBuilder: (_) {
-                    final langs = settingsProvider.learningLanguageCodes;
-                    return [
-                      ...langs.map((code) {
-                        final lang = AppLanguageExtension.fromCode(code);
-                        return PopupMenuItem(
-                          value: code,
-                          child: Text(lang?.displayName ?? code),
-                        );
-                      }),
-                      const PopupMenuDivider(),
-                      const PopupMenuItem(
-                        value: 'add_more',
-                        child: Text('+ Add language'),
-                      ),
-                    ];
-                  },
-                )
-                : null,
+        leading: null,
       ),
 
       body: Stack(
@@ -83,6 +86,17 @@ class HomeScreen extends StatelessWidget {
             child: Column(
               children: [
                 const SizedBox(height: 50),
+                if (learningCodes.isNotEmpty)
+                  _LanguageMenu(
+                    codes: learningCodes,
+                    onTap: (code) {
+                      context
+                          .read<SettingsProvider>()
+                          .switchLearningLanguage(code);
+                    },
+                    onAdd: () => _showAddLanguageDialog(context),
+                  ),
+                const SizedBox(height: 20),
 
                 // Streak circle
                 Center(
@@ -366,6 +380,83 @@ class _NavCircleButton extends StatelessWidget {
           border: Border.all(color: primary, width: 2),
         ),
         child: Icon(icon, color: Colors.white),
+      ),
+    );
+  }
+}
+
+class _LanguageMenu extends StatelessWidget {
+  final List<String> codes;
+  final void Function(String) onTap;
+  final VoidCallback? onAdd;
+
+  const _LanguageMenu({
+    Key? key,
+    required this.codes,
+    required this.onTap,
+    this.onAdd,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedCode = codes.isNotEmpty ? codes.first : '';
+    final selectedLang = AppLanguageExtension.fromCode(selectedCode);
+    final selectedLabel =
+        '${selectedLang?.flag ?? ''} ${selectedLang?.displayName ?? selectedCode}';
+
+    return Container(
+      alignment: Alignment.centerLeft,
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      child: PopupMenuButton<String>(
+        onSelected: (code) {
+          if (code == 'add_more') {
+            if (onAdd != null) onAdd!();
+            return;
+          }
+          onTap(code);
+        },
+        itemBuilder: (context) {
+          final items = <PopupMenuEntry<String>>[];
+          for (final code in codes) {
+            if (code == selectedCode) continue;
+            final lang = AppLanguageExtension.fromCode(code);
+            final label = '${lang?.flag ?? ''} ${lang?.displayName ?? code}';
+            items.add(PopupMenuItem<String>(
+              value: code,
+              child: Text(label),
+            ));
+          }
+          items.add(const PopupMenuDivider());
+          items.add(const PopupMenuItem<String>(
+            value: 'add_more',
+            child: Text('+ Add'),
+          ));
+          return items;
+        },
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.2),
+            borderRadius: BorderRadius.circular(30),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.1),
+                blurRadius: 8,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                selectedLabel,
+                style: const TextStyle(color: Colors.white),
+              ),
+              const Icon(Icons.arrow_drop_down, color: Colors.white),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/presentation/screens/review_screen.dart
+++ b/lib/presentation/screens/review_screen.dart
@@ -67,7 +67,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
     if (s != null) {
       final langCode =
           context.read<SettingsProvider>().learningLanguageCodes.first;
-      await _loadAudioForSentence(s.id);
+      await _loadAudioForSentence(s.id(langCode));
     }
   }
 
@@ -199,7 +199,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id);
+                        _loadAudioForSentence(nxt.id(langCode));
                       }
                     },
                     onNextSentence: () {
@@ -211,7 +211,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id);
+                        _loadAudioForSentence(nxt.id(langCode));
                       }
                     },
                   ),
@@ -240,7 +240,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                         .read<SettingsProvider>()
                                         .learningLanguageCodes
                                         .first;
-                                _loadAudioForSentence(nxt.id);
+                                _loadAudioForSentence(nxt.id(langCode));
                               }
                             },
                             child: Text(label),

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -107,11 +107,11 @@ class _StudyScreenState extends State<StudyScreen> {
     });
 
     if (initial.isNotEmpty) {
-      await _loadAudioForSentence(initial[0].id);
+      await _loadAudioForSentence(initial[0].id(langCode));
     }
 
     // 2) fetch “the rest”
-    final excludeIds = initial.map((s) => s.id).toList();
+    final excludeIds = initial.map((s) => s.id(langCode)).toList();
     final rest = await _learningService.getRemainingSentencesForWord(
       batch.first.text,
       excludeIds,
@@ -220,7 +220,7 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id);
+    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
   }
 
   void _prevSentence() {
@@ -232,7 +232,7 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id);
+    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
   }
 
   @override

--- a/lib/services/learning_service.dart
+++ b/lib/services/learning_service.dart
@@ -94,7 +94,7 @@ class LearningService {
   ) async {
     final all = await sentenceRepo.fetchForWord(wordText, languageCode);
     return all
-        .where((s) => !excludeIds.contains(s.idFor(languageCode)))
+        .where((s) => !excludeIds.contains(s.id(languageCode)))
         .toList();
   }
 


### PR DESCRIPTION
## Summary
- allow selecting extra languages from HomeScreen
- extend `_LanguageMenu` with add callback
- support adding languages in `SettingsProvider`

## Testing
- `dart format lib/presentation/screens/home_screen.dart lib/presentation/providers/settings_provider.dart` *(fails: `dart: command not found`)*
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68402cbd9bf08321bda5e302ae3e82ab