### PR TITLE
Implement adding languages and onboarding fix

### DIFF
--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -35,11 +35,13 @@ class SettingsProvider extends ChangeNotifier {
   String? _nativeLanguageCode; // код родного языка: 'en','ru', ...
   List<String> _learningLanguageCodes =
       []; // список изучаемых языков: ['es','de', ...]
+  bool _isLoaded = false;
 
   /// Геттеры:
   String? get nativeLanguageCode => _nativeLanguageCode;
   List<String> get learningLanguageCodes =>
       List.unmodifiable(_learningLanguageCodes);
+  bool get isLoaded => _isLoaded;
 
   SettingsProvider() {
     _loadAll();
@@ -47,6 +49,7 @@ class SettingsProvider extends ChangeNotifier {
 
   /// Internal load/reset logic.
   Future<void> _loadAll() async {
+    _isLoaded = false;
     final prefs = await SharedPreferences.getInstance();
 
     // --- Locale (интерфейс приложения) ---
@@ -89,6 +92,7 @@ class SettingsProvider extends ChangeNotifier {
       _studiedCount = prefs.getInt(_kStudiedCountKey) ?? 0;
     }
 
+    _isLoaded = true;
     notifyListeners();
   }
 
@@ -141,6 +145,16 @@ class SettingsProvider extends ChangeNotifier {
     _learningLanguageCodes = List.from(codes);
     final prefs = await SharedPreferences.getInstance();
     await prefs.setStringList(_kLearningLanguagesKey, codes);
+    notifyListeners();
+  }
+
+  /// Add a new learning language to the front of the list if not already
+  /// present. The new language becomes the active learning language.
+  Future<void> addLearningLanguage(String code) async {
+    if (_learningLanguageCodes.contains(code)) return;
+    _learningLanguageCodes.insert(0, code);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kLearningLanguagesKey, _learningLanguageCodes);
     notifyListeners();
   }
 

--- a/lib/presentation/screens/onboarding_screen.dart
+++ b/lib/presentation/screens/onboarding_screen.dart
@@ -196,7 +196,10 @@ class InitialEntryRedirect extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final settings = context.read<SettingsProvider>();
+    final settings = context.watch<SettingsProvider>();
+    if (!settings.isLoaded) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
     // Если языки не выбраны, открываем Onboarding:
     if (settings.learningLanguageCodes.isEmpty ||
         settings.nativeLanguageCode == null) {


### PR DESCRIPTION
## Summary
- add a loading flag and new language insert in `SettingsProvider`
- show a dialog to add a learning language from `HomeScreen`
- only display onboarding when languages haven't been selected

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684043791c888321980bbaed155cb32a