### PR TITLE
Implement adding languages and onboarding fix

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -22,11 +22,39 @@ class HomeScreen extends StatelessWidget {
     final daily = settingsProvider.dailyCount;
     final progress = daily > 0 ? (studied / daily).clamp(0.0, 1.0) : 0.0;
     final streak = settingsProvider.streakCount;
+    final lastDate = settingsProvider.lastStreakDate;
     final loc = AppLocalizations.of(context)!;
     final learningCodes = settingsProvider.learningLanguageCodes;
     final leadCode = learningCodes.isNotEmpty
         ? AppLanguageExtension.fromCode(learningCodes.first)?.displayName ?? ''
         : '';
+
+    Future<String?> _showAddLanguageDialog() {
+      final available = AppLanguage.values
+          .where((lang) =>
+              !settingsProvider.learningLanguageCodes.contains(lang.code) &&
+              lang.code != settingsProvider.nativeLanguageCode)
+          .toList();
+      if (available.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('No more languages')),
+        );
+        return Future.value(null);
+      }
+      return showDialog<String>(
+        context: context,
+        builder: (ctx) => SimpleDialog(
+          title: const Text('Add language'),
+          children: [
+            for (final lang in available)
+              SimpleDialogOption(
+                onPressed: () => Navigator.pop(ctx, lang.code),
+                child: Text('${lang.flag} ${lang.displayName}'),
+              )
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       backgroundColor: Colors.transparent,
@@ -52,16 +80,18 @@ class HomeScreen extends StatelessWidget {
           SafeArea(
             child: Column(
               children: [
-                const SizedBox(height: 50),
+                const SizedBox(height: 20),
                 if (learningCodes.isNotEmpty)
                   _LanguageMenu(
-
                     codes: learningCodes,
-                    onTap: (code) {
+                    onTap: (code) async {
                       if (code == 'add_more') {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Feature coming soon')),
-                        );
+                        final newCode = await _showAddLanguageDialog();
+                        if (newCode != null) {
+                          await context
+                              .read<SettingsProvider>()
+                              .addLearningLanguage(newCode);
+                        }
                         return;
                       }
                       context
@@ -73,50 +103,9 @@ class HomeScreen extends StatelessWidget {
 
                 // Streak circle
                 Center(
-                  child: Container(
-                    width: 160,
-                    height: 160,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      gradient: const LinearGradient(
-                        colors: [Color(0xFFFFCA61), Color(0xFFFF6B6B)],
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                      ),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withOpacity(0.15),
-                          blurRadius: 12,
-                          offset: const Offset(0, 6),
-                        ),
-                      ],
-                    ),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        const Icon(
-                          Icons.local_fire_department,
-                          size: 40,
-                          color: Colors.white,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          '$streak',
-                          style: const TextStyle(
-                            fontSize: 36,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.white,
-                          ),
-                        ),
-                        Text(
-                          loc.streak,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            color: Colors.white,
-                          ),
-                        ),
-                      ],
-                    ),
+                  child: _StreakVisual(
+                    streak: streak,
+                    lastDate: lastDate,
                   ),
                 ),
                 const SizedBox(height: 40),
@@ -325,6 +314,95 @@ class _SmallCard extends StatelessWidget {
                 softWrap: true, // enable wrapping
                 // no overflow specified, so it will wrap
               ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StreakVisual extends StatelessWidget {
+  final int streak;
+  final String? lastDate;
+  const _StreakVisual({required this.streak, required this.lastDate});
+
+  @override
+  Widget build(BuildContext context) {
+    final today = DateTime.now().toIso8601String().split('T').first;
+    final bool broken = streak == 0 && lastDate != null && lastDate != today;
+
+    Color color;
+    String emoji;
+    String message;
+
+    if (broken) {
+      color = Colors.black54;
+      emoji = '💀';
+      message = 'Streak is dead. Bring it back tomorrow!';
+    } else if (streak == 0) {
+      color = Colors.yellow;
+      emoji = '🪔';
+      message = "Let's ignite your streak!";
+    } else if (streak <= 4) {
+      color = Colors.orange;
+      emoji = '🔥';
+      message = 'Keep going!';
+    } else if (streak <= 9) {
+      color = Colors.red;
+      emoji = '🔥🔥';
+      message = 'Momentum!';
+    } else if (streak <= 19) {
+      color = Colors.deepOrange;
+      emoji = '🏮';
+      message = 'Torch blazing!';
+    } else if (streak <= 29) {
+      color = Colors.deepOrangeAccent;
+      emoji = '🔥🔥🔥';
+      message = 'Bonfire!';
+    } else if (streak <= 49) {
+      color = Colors.purple;
+      emoji = '🔥⭕';
+      message = 'Fire ring!';
+    } else {
+      color = Colors.pinkAccent;
+      emoji = '🎆';
+      message = 'Legendary streak!';
+    }
+
+    return Container(
+      width: 160,
+      height: 160,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.15),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 40)),
+          const SizedBox(height: 8),
+          Text(
+            '$streak',
+            style: const TextStyle(
+              fontSize: 36,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 14, color: Colors.white),
             ),
           ),
         ],

--- a/lib/presentation/screens/onboarding_screen.dart
+++ b/lib/presentation/screens/onboarding_screen.dart
@@ -196,7 +196,10 @@ class InitialEntryRedirect extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final settings = context.read<SettingsProvider>();
+    final settings = context.watch<SettingsProvider>();
+    if (!settings.isLoaded) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
     // Если языки не выбраны, открываем Onboarding:
     if (settings.learningLanguageCodes.isEmpty ||
         settings.nativeLanguageCode == null) {

--- a/lib/presentation/screens/stats_screen.dart
+++ b/lib/presentation/screens/stats_screen.dart
@@ -51,7 +51,7 @@ class StatsScreen extends StatelessWidget {
                 _StatCard(
                   icon: Icons.local_fire_department,
                   label: loc.current_streak,
-                  value: '${settings.streakCount} ${settings.streakCount == 1 ? 'day' : 'days'}',
+                  value: _streakLabel(settings.streakCount),
                 ),
                 const SizedBox(height: 16),
                 _StatCard(
@@ -112,4 +112,14 @@ class _StatCard extends StatelessWidget {
       ),
     );
   }
+}
+
+String _streakLabel(int streak) {
+  if (streak == 0) return '0 🪔';
+  if (streak <= 4) return '$streak 🔥';
+  if (streak <= 9) return '$streak 🔥🔥';
+  if (streak <= 19) return '$streak 🏮';
+  if (streak <= 29) return '$streak 🔥🔥🔥';
+  if (streak <= 49) return '$streak 🔥⭕';
+  return '$streak 🎆';
 }

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -267,8 +267,16 @@ class _StudyScreenState extends State<StudyScreen> {
                 isPlaying: _isPlaying,
                 position: _position,
                 duration: _duration,
-                onToggleAudio: () => _togglePlay(_audioLinks.first.audioId),
-                onReplayAudio: () => _togglePlay(_audioLinks.first.audioId),
+                onToggleAudio: () {
+                  if (_audioLinks.isNotEmpty) {
+                    _togglePlay(_audioLinks.first.audioId);
+                  }
+                },
+                onReplayAudio: () {
+                  if (_audioLinks.isNotEmpty) {
+                    _togglePlay(_audioLinks.first.audioId);
+                  }
+                },
                 onPrevSentence: _prevSentence,
                 onNextSentence: _nextSentence,
               ),


### PR DESCRIPTION
## Summary
- add a loading flag and new language insert in `SettingsProvider`
- show a dialog to add a learning language from `HomeScreen`
- only display onboarding when languages haven't been selected
- adjust menu spacing and guard audio replay when no audio loaded

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684043791c888321980bbaed155cb32a