### PR TITLE
Add permission request screen

### DIFF
--- a/lib/presentation/screens/onboarding_screen.dart
+++ b/lib/presentation/screens/onboarding_screen.dart
@@ -5,8 +5,7 @@ import 'package:provider/provider.dart';
 import '../../core/app_language.dart';
 import '../providers/settings_provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:learn_languages/presentation/screens/home_screen.dart';
-import 'package:learn_languages/presentation/providers/settings_provider.dart';
+import 'permission_request_screen.dart';
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({Key? key}) : super(key: key);
@@ -53,9 +52,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     settings.setLearningLanguages(_selectedLearning);
     settings.setDailyCount(count);
 
-    // После сохранения переходим в HomeScreen (заменяем маршрут)
+    // After saving, show permission request screen
     Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const InitialEntryRedirect()),
+      MaterialPageRoute(builder: (_) => const PermissionRequestScreen()),
     );
   }
 

--- a/lib/presentation/screens/permission_request_screen.dart
+++ b/lib/presentation/screens/permission_request_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'onboarding_screen.dart';
+
+class PermissionRequestScreen extends StatelessWidget {
+  const PermissionRequestScreen({Key? key}) : super(key: key);
+
+  Future<void> _requestPermissions(BuildContext context) async {
+    if (await Permission.microphone.isDenied) {
+      await Permission.microphone.request();
+    }
+    // Internet permission is granted at install time.
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const InitialEntryRedirect()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(loc.appTitle)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'This app requires Internet access to download learning content.',
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Audio permission is needed to record your voice and check pronunciation.',
+            ),
+            const SizedBox(height: 32),
+            Center(
+              child: ElevatedButton(
+                onPressed: () => _requestPermissions(context),
+                child: const Text('Allow'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a screen that explains required permissions and asks for microphone access
- route to this permission request screen after onboarding
- tidy imports in onboarding screen

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a07213cc832197477120bc704261