### PR TITLE
Filter sentences by language-specific audio

### DIFF
--- a/lib/data/local/local_audio_repo.dart
+++ b/lib/data/local/local_audio_repo.dart
@@ -2,18 +2,32 @@
 import 'package:sqflite/sqflite.dart';
 import '../../domain/entities/audio_link.dart';
 import '../../domain/repositories/i_audio_repository.dart';
+import '../../core/app_language.dart';
 
 class LocalAudioRepository implements IAudioRepository {
   final Database db;
   LocalAudioRepository(this.db);
 
   @override
-  Future<List<AudioLink>> fetchForSentence(String sentenceId) async {
-    // Логируем входящий sentenceId
-    print('🔍 [LocalAudioRepo] fetchForSentence sentenceId=$sentenceId');
+  Future<List<AudioLink>> fetchForSentence(
+    String sentenceId,
+    String languageCode,
+  ) async {
+    // Determine table based on language code
+    final lang = AppLanguageExtension.fromCode(languageCode);
+    if (lang == null) {
+      print('⚠️ [LocalAudioRepo] Unsupported languageCode="$languageCode"');
+      return [];
+    }
+    final table = '${lang.name}_audio';
+
+    // Логируем входящие параметры
+    print(
+        '🔍 [LocalAudioRepo] fetchForSentence sentenceId=$sentenceId table=$table');
+
     // Выполняем запрос
     final rows = await db.query(
-      'sentences_with_audio',
+      table,
       where: 'sentence_id = ?',
       whereArgs: [sentenceId],
     );

--- a/lib/data/local/local_sentence_repo.dart
+++ b/lib/data/local/local_sentence_repo.dart
@@ -30,13 +30,13 @@ class LocalSentenceRepository implements ISentenceRepository {
       return [];
     }
 
-    final column =
-        '${langEnum.name}_text'; // e.g. "english_text", "russian_text", etc.
+    final column = '${langEnum.name}_text'; // e.g. "english_text"
+    final audioColumn = '${langEnum.name}_audio';
     final limitClause = limit != null ? 'LIMIT $limit' : '';
     final sql = '''
       SELECT *
       FROM sentences
-      WHERE $column LIKE ?
+      WHERE $column LIKE ? AND $audioColumn = 1
       ORDER BY RANDOM()
       $limitClause
     ''';

--- a/lib/domain/repositories/i_audio_repository.dart
+++ b/lib/domain/repositories/i_audio_repository.dart
@@ -4,6 +4,9 @@ import '../entities/audio_link.dart';
 
 /// Provides audio links associated with sentences.
 abstract class IAudioRepository {
-  /// Fetch all audio links for the given [sentenceId].
-  Future<List<AudioLink>> fetchForSentence(String sentenceId);
+  /// Fetch all audio links for the given [sentenceId] in a specific language.
+  Future<List<AudioLink>> fetchForSentence(
+    String sentenceId,
+    String languageCode,
+  );
 }

--- a/lib/presentation/screens/review_screen.dart
+++ b/lib/presentation/screens/review_screen.dart
@@ -67,11 +67,14 @@ class _ReviewScreenState extends State<ReviewScreen> {
     if (s != null) {
       final langCode =
           context.read<SettingsProvider>().learningLanguageCodes.first;
-      await _loadAudioForSentence(s.id(langCode));
+      await _loadAudioForSentence(s.id(langCode), langCode);
     }
   }
 
-  Future<void> _loadAudioForSentence(String sentenceId) async {
+  Future<void> _loadAudioForSentence(
+    String sentenceId,
+    String languageCode,
+  ) async {
     if (!mounted) return;
     setState(() {
       _loadingAudio = true;
@@ -83,6 +86,7 @@ class _ReviewScreenState extends State<ReviewScreen> {
 
     final links = await context.read<LearningService>().getAudioForSentence(
       sentenceId,
+      languageCode,
     );
 
     if (!mounted) return;
@@ -199,7 +203,10 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id(langCode));
+                        _loadAudioForSentence(
+                          nxt.id(langCode),
+                          langCode,
+                        );
                       }
                     },
                     onNextSentence: () {
@@ -211,7 +218,10 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                 .read<SettingsProvider>()
                                 .learningLanguageCodes
                                 .first;
-                        _loadAudioForSentence(nxt.id(langCode));
+                        _loadAudioForSentence(
+                          nxt.id(langCode),
+                          langCode,
+                        );
                       }
                     },
                   ),
@@ -240,7 +250,10 @@ class _ReviewScreenState extends State<ReviewScreen> {
                                         .read<SettingsProvider>()
                                         .learningLanguageCodes
                                         .first;
-                                _loadAudioForSentence(nxt.id(langCode));
+                                _loadAudioForSentence(
+                                  nxt.id(langCode),
+                                  langCode,
+                                );
                               }
                             },
                             child: Text(label),

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -107,7 +107,7 @@ class _StudyScreenState extends State<StudyScreen> {
     });
 
     if (initial.isNotEmpty) {
-      await _loadAudioForSentence(initial[0].id(langCode));
+      await _loadAudioForSentence(initial[0].id(langCode), langCode);
     }
 
     // 2) fetch “the rest”
@@ -122,7 +122,10 @@ class _StudyScreenState extends State<StudyScreen> {
     setState(() => _sentences.addAll(rest));
   }
 
-  Future<void> _loadAudioForSentence(String sentenceId) async {
+  Future<void> _loadAudioForSentence(
+    String sentenceId,
+    String languageCode,
+  ) async {
     if (!mounted) return;
     setState(() {
       _audioLoading = true;
@@ -132,7 +135,10 @@ class _StudyScreenState extends State<StudyScreen> {
       _isPlaying = false;
     });
 
-    final links = await _learningService.getAudioForSentence(sentenceId);
+    final links = await _learningService.getAudioForSentence(
+      sentenceId,
+      languageCode,
+    );
 
     if (!mounted) return;
     setState(() {
@@ -220,7 +226,10 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
+    _loadAudioForSentence(
+      _sentences[_sentenceIndex].id(langCode),
+      langCode,
+    );
   }
 
   void _prevSentence() {
@@ -232,7 +241,10 @@ class _StudyScreenState extends State<StudyScreen> {
     });
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
-    _loadAudioForSentence(_sentences[_sentenceIndex].id(langCode));
+    _loadAudioForSentence(
+      _sentences[_sentenceIndex].id(langCode),
+      langCode,
+    );
   }
 
   @override

--- a/lib/services/learning_service.dart
+++ b/lib/services/learning_service.dart
@@ -98,8 +98,11 @@ class LearningService {
         .toList();
   }
 
-  Future<List<AudioLink>> getAudioForSentence(String sentenceId) {
-    return audioRepo.fetchForSentence(sentenceId);
+  Future<List<AudioLink>> getAudioForSentence(
+    String sentenceId,
+    String languageCode,
+  ) {
+    return audioRepo.fetchForSentence(sentenceId, languageCode);
   }
 
   Future<List<Word>> getDueWords() async {


### PR DESCRIPTION
## Summary
- filter sentences by language-specific audio column
- fetch audio from language-specific tables
- update service layer and screens to use language-aware audio

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844415837a083219a93e655ed124558