### PR TITLE
Add language selection for custom word entry

### DIFF
--- a/lib/data/local/local_custom_word_repo.dart
+++ b/lib/data/local/local_custom_word_repo.dart
@@ -10,18 +10,32 @@ class LocalCustomWordRepository implements ICustomWordRepository {
     db.execute('''
       CREATE TABLE IF NOT EXISTS $_table(
         id TEXT PRIMARY KEY,
-        text TEXT NOT NULL
+        text TEXT NOT NULL,
+        language_code TEXT NOT NULL
       );
     ''');
   }
 
   @override
-  Future<void> add(CustomWord word) =>
-      db.insert(_table, word.toMap(), conflictAlgorithm: ConflictAlgorithm.replace);
+  Future<void> add(CustomWord word) => db.insert(
+        _table,
+        word.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
 
   @override
   Future<List<CustomWord>> fetchAll() async {
     final rows = await db.query(_table);
+    return rows.map((m) => CustomWord.fromMap(m)).toList();
+  }
+
+  @override
+  Future<List<CustomWord>> fetchByLanguage(String languageCode) async {
+    final rows = await db.query(
+      _table,
+      where: 'language_code = ?',
+      whereArgs: [languageCode],
+    );
     return rows.map((m) => CustomWord.fromMap(m)).toList();
   }
 

--- a/lib/domain/entities/custom_word.dart
+++ b/lib/domain/entities/custom_word.dart
@@ -2,13 +2,24 @@ class CustomWord {
   final String id;
   final String text;
 
-  CustomWord({required this.id, required this.text});
+  /// Language code for this custom word (e.g. 'en', 'es').
+  final String languageCode;
 
-  factory CustomWord.fromMap(Map<String, dynamic> m) =>
-      CustomWord(id: m['id'] as String, text: m['text'] as String);
+  CustomWord({
+    required this.id,
+    required this.text,
+    required this.languageCode,
+  });
+
+  factory CustomWord.fromMap(Map<String, dynamic> m) => CustomWord(
+        id: m['id'] as String,
+        text: m['text'] as String,
+        languageCode: m['language_code'] as String,
+      );
 
   Map<String, dynamic> toMap() => {
         'id': id,
         'text': text,
+        'language_code': languageCode,
       };
 }

--- a/lib/domain/repositories/i_custom_word_repository.dart
+++ b/lib/domain/repositories/i_custom_word_repository.dart
@@ -3,6 +3,10 @@ import '../entities/custom_word.dart';
 /// Stores and retrieves user-added custom words.
 abstract class ICustomWordRepository {
   Future<List<CustomWord>> fetchAll();
+
+  /// Fetch words for a specific [languageCode].
+  Future<List<CustomWord>> fetchByLanguage(String languageCode);
+
   Future<void> add(CustomWord word);
   Future<void> remove(String id);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -86,11 +86,9 @@ class MyApp extends StatelessWidget {
               ),
         ),
         ChangeNotifierProvider<CustomWordsProvider>(
-          create:
-              (_) => CustomWordsProvider(
-                getIt<IWordRepository>(),
-                getIt<ISRSRepository>(),
-              ),
+          create: (_) => CustomWordsProvider(
+            getIt<ICustomWordRepository>(),
+          ),
         ),
         ChangeNotifierProvider<TaskProvider>(
           create:

--- a/lib/presentation/providers/custom_words_provider.dart
+++ b/lib/presentation/providers/custom_words_provider.dart
@@ -3,41 +3,33 @@
 import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
-import '../../domain/entities/word.dart';
-import '../../domain/repositories/i_word_repository.dart';
-import '../../domain/repositories/i_srs_repository.dart';
+import '../../domain/entities/custom_word.dart';
+import '../../domain/repositories/i_custom_word_repository.dart';
 
 class CustomWordsProvider extends ChangeNotifier {
-  final IWordRepository _wordRepo;
-  final ISRSRepository _srs;
+  final ICustomWordRepository _repo;
   final _uuid = Uuid();
 
-  List<Word> _words = [];
-  List<Word> get words => List.unmodifiable(_words);
+  List<CustomWord> _words = [];
+  List<CustomWord> get words => List.unmodifiable(_words);
 
-  CustomWordsProvider(this._wordRepo, this._srs) {
+  CustomWordsProvider(this._repo) {
     _load();
   }
 
   Future<void> _load() async {
-    // load all words and keep only custom ones
-    final all = await _wordRepo.fetchAll();
-    _words = all.where((w) => w.type == WordType.custom).toList();
+    _words = await _repo.fetchAll();
     notifyListeners();
   }
 
-  Future<void> add(
-      String text, {
-        String? translation,
-        String? sentence,
-      }) async {
+  Future<void> add(String text, String languageCode) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
 
     // 1) See if this text already exists among custom words
-    Word? existing;
+    CustomWord? existing;
     for (final w in _words) {
-      if (w.text == trimmed) {
+      if (w.text == trimmed && w.languageCode == languageCode) {
         existing = w;
         break;
       }
@@ -45,35 +37,21 @@ class CustomWordsProvider extends ChangeNotifier {
 
     // 2) Build the new-or-updated Word
     final id = existing?.id ?? _uuid.v4();
-    final word = Word(
+    final word = CustomWord(
       id: id,
       text: trimmed,
-      translation: translation,
-      sentence: sentence,
-      type: WordType.custom,
+      languageCode: languageCode,
     );
 
     // 3) Insert or replace in DB
-    await _wordRepo.addOrUpdate(word);
+    await _repo.add(word);
 
-
-
-    // 5) Reload our in-memory list and notify
+    // 4) Reload our in-memory list and notify
     await _load();
   }
 
   Future<void> remove(String id) async {
-    // On delete, revert it back to a normal word
-    final all = await _wordRepo.fetchAll();
-    final original = all.firstWhere((w) => w.id == id);
-    final updated = Word(
-      id: original.id,
-      text: original.text,
-      translation: original.translation,
-      sentence: original.sentence,
-      type: WordType.normal,
-    );
-    await _wordRepo.addOrUpdate(updated);
+    await _repo.remove(id);
     await _load();
   }
 }

--- a/lib/presentation/screens/custom_words_screen.dart
+++ b/lib/presentation/screens/custom_words_screen.dart
@@ -3,6 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/custom_words_provider.dart';
+import '../providers/settings_provider.dart';
+import '../../core/app_language.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class CustomWordsScreen extends StatefulWidget {
@@ -16,12 +18,17 @@ class CustomWordsScreen extends StatefulWidget {
 class _CustomWordsScreenState extends State<CustomWordsScreen> {
   late final TextEditingController _ctrl;
   late final FocusNode _focusNode;
+  String? _selectedLang;
 
   @override
   void initState() {
     super.initState();
     _ctrl = TextEditingController(text: widget.initialText ?? '');
     _focusNode = FocusNode();
+    final settings = context.read<SettingsProvider>();
+    _selectedLang = settings.learningLanguageCodes.isNotEmpty
+        ? settings.learningLanguageCodes.first
+        : null;
     // wait until build finishes, then focus:
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _focusNode.requestFocus();
@@ -39,6 +46,8 @@ class _CustomWordsScreenState extends State<CustomWordsScreen> {
   Widget build(BuildContext context) {
     final vm = context.watch<CustomWordsProvider>();
     final loc = AppLocalizations.of(context)!;
+    final settings = context.watch<SettingsProvider>();
+    final learningCodes = settings.learningLanguageCodes;
 
     return Scaffold(
       appBar: AppBar(title:  Text(loc.add_custom_word)),
@@ -46,28 +55,50 @@ class _CustomWordsScreenState extends State<CustomWordsScreen> {
         children: [
           Padding(
             padding: const EdgeInsets.all(16),
-            child: Row(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Expanded(
-                  child: TextField(
-                    focusNode: _focusNode,            // ← auto-focus here
-                    controller: _ctrl,
-                    decoration:  InputDecoration(
-                      labelText: loc.new_word,
-                    ),
-                  ),
+                DropdownButton<String>(
+                  value: _selectedLang,
+                  hint: Text(loc.language),
+                  items: learningCodes
+                      .map(
+                        (code) => DropdownMenuItem<String>(
+                          value: code,
+                          child: Text(AppLanguageExtension.fromCode(code)?.displayName ?? code),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (val) => setState(() => _selectedLang = val),
                 ),
-                IconButton(
-                  icon: const Icon(Icons.add),
-                  onPressed: () {
-                    final text = _ctrl.text.trim();
-                    if (text.isEmpty) return;
-                    context.read<CustomWordsProvider>().add(text);
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('${loc.added} “$text”')),
-                    );
-                    _ctrl.clear();
-                  },
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        focusNode: _focusNode,
+                        controller: _ctrl,
+                        decoration:  InputDecoration(
+                          labelText: loc.new_word,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.add),
+                      onPressed: _selectedLang == null
+                          ? null
+                          : () {
+                              final text = _ctrl.text.trim();
+                              if (text.isEmpty) return;
+                              context
+                                  .read<CustomWordsProvider>()
+                                  .add(text, _selectedLang!);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('${loc.added} “$text”')),
+                              );
+                              _ctrl.clear();
+                            },
+                    ),
+                  ],
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- support specifying language code for custom words
- persist language code in custom words repository
- update provider to use custom word repo and accept language code
- allow choosing from learning languages on custom word screen
- update DI for new provider

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68446991c5888321a914aa80a5932aaf