### PR TITLE
Fix home screen study availability and streak text

### DIFF
--- a/lib/presentation/providers/home_provider.dart
+++ b/lib/presentation/providers/home_provider.dart
@@ -47,10 +47,17 @@ class HomeProvider extends ChangeNotifier {
   }
 
   Future<void> _loadCanStudy() async {
-    final batch = await _learningService.getDailyBatch(
-      _settingsProvider.dailyCount,
-    );
-    _canStudy = batch.isNotEmpty;
+    final daily = _settingsProvider.dailyCount;
+    final studied = _settingsProvider.studiedCount;
+
+    if (studied >= daily) {
+      _canStudy = false;
+      notifyListeners();
+      return;
+    }
+
+    final batch = await _learningService.getDailyBatch(daily);
+    _canStudy = batch.isNotEmpty && studied < daily;
     notifyListeners();
   }
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -401,25 +401,26 @@ class _StreakVisual extends StatelessWidget {
               color: Colors.white,
             ),
           ),
-           LayoutBuilder(
-              builder: (context, constraints) {
-                // constrain to available width
-                return FittedBox(
-                  fit: BoxFit.scaleDown,
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(maxWidth: constraints.maxWidth),
-                    child: Text(
-                      message,
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(fontSize: 14, color: Colors.white),
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                      softWrap: true,
-                    ),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final width = constraints.maxWidth - 16; // padding inside circle
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: width),
+                  child: Text(
+                    message,
+                    textAlign: TextAlign.center,
+                    style:
+                        const TextStyle(fontSize: 14, color: Colors.white),
+                    maxLines: 3,
+                    softWrap: true,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                );
-              },
-            ),
+                ),
+              );
+            },
+          ),
 
 
         ],


### PR DESCRIPTION
## Summary
- disable "Start Study" button when daily limit is reached
- keep streak message text inside circle

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y dart` *(fails: `Unable to locate package`)*

------
https://chatgpt.com/codex/tasks/task_e_6847665d9f78832189fb0c6bbdb3a2bd