### PR TITLE
Implement fallback when no audio sentences found

### DIFF
--- a/lib/data/local/local_sentence_repo.dart
+++ b/lib/data/local/local_sentence_repo.dart
@@ -21,6 +21,7 @@ class LocalSentenceRepository implements ISentenceRepository {
     String languageCode, {
     int? limit,
     bool onlyWithAudio = true,
+    String? translationCode,
   }) async {
     final langEnum = AppLanguageExtension.fromCode(languageCode);
     if (langEnum == null) {
@@ -29,12 +30,20 @@ class LocalSentenceRepository implements ISentenceRepository {
 
     final column = '${langEnum.name}_text'; // e.g. "english_text"
     final audioColumn = '${langEnum.name}_audio';
+    final translationEnum = translationCode != null
+        ? AppLanguageExtension.fromCode(translationCode)
+        : null;
+    final translationColumn =
+        translationEnum != null ? '${translationEnum.name}_text' : null;
     final limitClause = limit != null ? 'LIMIT $limit' : '';
     final audioCondition = onlyWithAudio ? 'AND $audioColumn = 1' : '';
+    final translationCondition = translationColumn != null
+        ? 'AND $translationColumn IS NOT NULL AND $translationColumn != ""'
+        : '';
     final sql = '''
       SELECT *
       FROM sentences
-      WHERE $column LIKE ? $audioCondition
+      WHERE $column LIKE ? $audioCondition $translationCondition
       ORDER BY RANDOM()
       $limitClause
     ''';

--- a/lib/data/local/local_sentence_repo.dart
+++ b/lib/data/local/local_sentence_repo.dart
@@ -20,6 +20,7 @@ class LocalSentenceRepository implements ISentenceRepository {
     String wordText,
     String languageCode, {
     int? limit,
+    bool onlyWithAudio = true,
   }) async {
     final langEnum = AppLanguageExtension.fromCode(languageCode);
     if (langEnum == null) {
@@ -29,10 +30,11 @@ class LocalSentenceRepository implements ISentenceRepository {
     final column = '${langEnum.name}_text'; // e.g. "english_text"
     final audioColumn = '${langEnum.name}_audio';
     final limitClause = limit != null ? 'LIMIT $limit' : '';
+    final audioCondition = onlyWithAudio ? 'AND $audioColumn = 1' : '';
     final sql = '''
       SELECT *
       FROM sentences
-      WHERE $column LIKE ? AND $audioColumn = 1
+      WHERE $column LIKE ? $audioCondition
       ORDER BY RANDOM()
       $limitClause
     ''';

--- a/lib/domain/repositories/i_sentence_repository.dart
+++ b/lib/domain/repositories/i_sentence_repository.dart
@@ -14,5 +14,6 @@ abstract class ISentenceRepository {
     String languageCode, {
     int? limit,
     bool onlyWithAudio = true,
+    String? translationCode,
   });
 }

--- a/lib/domain/repositories/i_sentence_repository.dart
+++ b/lib/domain/repositories/i_sentence_repository.dart
@@ -13,5 +13,6 @@ abstract class ISentenceRepository {
     String wordText,
     String languageCode, {
     int? limit,
+    bool onlyWithAudio = true,
   });
 }

--- a/lib/presentation/providers/home_provider.dart
+++ b/lib/presentation/providers/home_provider.dart
@@ -86,8 +86,14 @@ class HomeProvider extends ChangeNotifier {
         w.text,
         languageCode,
         limit: 3,
+        translationCode: _settingsProvider.nativeLanguageCode,
       );
-      _learningService.getRemainingSentencesForWord(w.text, [], languageCode);
+      _learningService.getRemainingSentencesForWord(
+        w.text,
+        [],
+        languageCode,
+        translationCode: _settingsProvider.nativeLanguageCode,
+      );
     }
   }
 }

--- a/lib/presentation/providers/review_provider.dart
+++ b/lib/presentation/providers/review_provider.dart
@@ -56,6 +56,7 @@ class ReviewProvider extends ChangeNotifier {
       currentWord!.text,
       langCode,
       limit: 3,
+      translationCode: _settings.nativeLanguageCode,
     );
     _sentenceIndex = 0;
     _initialLoaded = true;
@@ -67,6 +68,7 @@ class ReviewProvider extends ChangeNotifier {
       currentWord!.text,
       excludeIds,
       langCode,
+      translationCode: _settings.nativeLanguageCode,
     );
     _sentences.addAll(rest);
     notifyListeners();

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -93,12 +93,24 @@ class _StudyScreenState extends State<StudyScreen> {
     final langCode =
         context.read<SettingsProvider>().learningLanguageCodes.first;
 
-    // 1) load initial few examples:
-    final initial = await _learningService.getInitialSentencesForWord(
+    // 1) load initial few examples with audio if possible:
+    var initial = await _learningService.getInitialSentencesForWord(
       batch.first.text,
       langCode,
       limit: _initialLimit,
     );
+
+    // If no sentences have audio, fetch any sentences regardless of audio
+    bool withAudio = true;
+    if (initial.isEmpty) {
+      withAudio = false;
+      initial = await _learningService.getInitialSentencesForWord(
+        batch.first.text,
+        langCode,
+        limit: _initialLimit,
+        requireAudio: false,
+      );
+    }
 
     if (!mounted) return;
     setState(() {
@@ -117,6 +129,7 @@ class _StudyScreenState extends State<StudyScreen> {
       batch.first.text,
       excludeIds,
       langCode,
+      requireAudio: withAudio,
     );
 
     if (!mounted) return;

--- a/lib/presentation/widgets/interactive_word_sentence_card.dart
+++ b/lib/presentation/widgets/interactive_word_sentence_card.dart
@@ -387,12 +387,14 @@ class _InteractiveWordSentenceCardState
                                       )
                                       : Row(
                                         children: [
-                                          Icon(
-                                            Icons.volume_up,
-                                            color:
-                                                Theme.of(context).primaryColor,
-                                          ),
-                                          const SizedBox(width: 8),
+                                          if (widget.audioLinks.isNotEmpty)
+                                            Icon(
+                                              Icons.volume_up,
+                                              color:
+                                                  Theme.of(context).primaryColor,
+                                            ),
+                                          if (widget.audioLinks.isNotEmpty)
+                                            const SizedBox(width: 8),
                                           Expanded(
                                             child: SelectableText(
                                               current!.text(learnCode),

--- a/lib/services/learning_service.dart
+++ b/lib/services/learning_service.dart
@@ -111,12 +111,14 @@ class LearningService {
     String languageCode, {
     int limit = 3,
     bool requireAudio = true,
+    String? translationCode,
   }) {
     return sentenceRepo.fetchForWord(
       wordText,
       languageCode,
       limit: limit,
       onlyWithAudio: requireAudio,
+      translationCode: translationCode,
     );
   }
 
@@ -124,12 +126,13 @@ class LearningService {
     String wordText,
     List<String> excludeIds,
     String languageCode,
-    {bool requireAudio = true}
+    {bool requireAudio = true, String? translationCode}
   ) async {
     final all = await sentenceRepo.fetchForWord(
       wordText,
       languageCode,
       onlyWithAudio: requireAudio,
+      translationCode: translationCode,
     );
     return all
         .where((s) => !excludeIds.contains(s.id(languageCode)))

--- a/lib/services/learning_service.dart
+++ b/lib/services/learning_service.dart
@@ -110,16 +110,27 @@ class LearningService {
     String wordText,
     String languageCode, {
     int limit = 3,
+    bool requireAudio = true,
   }) {
-    return sentenceRepo.fetchForWord(wordText, languageCode, limit: limit);
+    return sentenceRepo.fetchForWord(
+      wordText,
+      languageCode,
+      limit: limit,
+      onlyWithAudio: requireAudio,
+    );
   }
 
   Future<List<Sentence>> getRemainingSentencesForWord(
     String wordText,
     List<String> excludeIds,
     String languageCode,
+    {bool requireAudio = true}
   ) async {
-    final all = await sentenceRepo.fetchForWord(wordText, languageCode);
+    final all = await sentenceRepo.fetchForWord(
+      wordText,
+      languageCode,
+      onlyWithAudio: requireAudio,
+    );
     return all
         .where((s) => !excludeIds.contains(s.id(languageCode)))
         .toList();


### PR DESCRIPTION
## Summary
- allow sentence repository to fetch sentences regardless of audio
- add optional `requireAudio` flag in `LearningService`
- update StudyScreen to load sentences without audio when needed

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b524223f08321837a50dfc987ea4f